### PR TITLE
 fix: 修复db2 char和varchar中文在linux下与windows字符集不同的问题

### DIFF
--- a/storage/database/db2/decode_chinese_linux.go
+++ b/storage/database/db2/decode_chinese_linux.go
@@ -1,0 +1,20 @@
+// Copyright 2020 the go-etl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db2
+
+//db2的char和varchar类型在linux下中文字符集是utf-8
+func decodeChinese(data []byte) ([]byte, error) {
+	return data, nil
+}

--- a/storage/database/db2/decode_chinese_linux_test.go
+++ b/storage/database/db2/decode_chinese_linux_test.go
@@ -1,0 +1,51 @@
+// Copyright 2020 the go-etl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db2
+
+import "testing"
+
+func TestScanner_Scan_Chinese(t *testing.T) {
+	type args struct {
+		src interface{}
+	}
+	tests := []struct {
+		name    string
+		s       *Scanner
+		args    args
+		wantErr bool
+		want    element.Column
+	}{
+		//"CHAR"  "VARCHAR"
+		{
+			name: "CHAR",
+			s:    NewScanner(NewField(database.NewBaseField(0, "test", newMockFieldType("CHAR")))),
+			args: args{
+				src: []byte("中文abc"),
+			},
+			want: element.NewDefaultColumn(element.NewStringColumnValue("中文abc"), "test", element.ByteSize([]byte("中文abc"))),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.s.Scan(tt.args.src); (err != nil) != tt.wantErr {
+				t.Errorf("Scanner.Scan() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(tt.s.Column(), tt.want) {
+				t.Errorf("Scanner.Column() = %v, want %v", tt.s.Column(), tt.want)
+			}
+		})
+	}
+}

--- a/storage/database/db2/decode_chinese_linux_test.go
+++ b/storage/database/db2/decode_chinese_linux_test.go
@@ -14,7 +14,13 @@
 
 package db2
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Breeze0806/go-etl/element"
+	"github.com/Breeze0806/go-etl/storage/database"
+)
 
 func TestScanner_Scan_Chinese(t *testing.T) {
 	type args struct {

--- a/storage/database/db2/decode_chinese_windows.go
+++ b/storage/database/db2/decode_chinese_windows.go
@@ -1,0 +1,22 @@
+// Copyright 2020 the go-etl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db2
+
+import "golang.org/x/text/encoding/simplifiedchinese"
+
+//db2的char和varchar类型在windows下中文字符集是gbk
+func decodeChinese(data []byte) ([]byte, error) {
+	return simplifiedchinese.GBK.NewDecoder().Bytes(data)
+}

--- a/storage/database/db2/decode_chinese_windows_test.go
+++ b/storage/database/db2/decode_chinese_windows_test.go
@@ -1,0 +1,66 @@
+// Copyright 2020 the go-etl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db2
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Breeze0806/go-etl/element"
+	"github.com/Breeze0806/go-etl/storage/database"
+	"golang.org/x/text/encoding/simplifiedchinese"
+)
+
+func gbk(data []byte) []byte {
+	v, err := simplifiedchinese.GBK.NewEncoder().Bytes(data)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func TestScanner_Scan_Chinese(t *testing.T) {
+	type args struct {
+		src interface{}
+	}
+	tests := []struct {
+		name    string
+		s       *Scanner
+		args    args
+		wantErr bool
+		want    element.Column
+	}{
+		//"CHAR"  "VARCHAR"
+		{
+			name: "CHAR",
+			s:    NewScanner(NewField(database.NewBaseField(0, "test", newMockFieldType("CHAR")))),
+			args: args{
+				src: gbk([]byte("中文abc")),
+			},
+			want: element.NewDefaultColumn(element.NewStringColumnValue("中文abc"), "test", element.ByteSize(gbk([]byte("中文abc")))),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.s.Scan(tt.args.src); (err != nil) != tt.wantErr {
+				t.Errorf("Scanner.Scan() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(tt.s.Column(), tt.want) {
+				t.Errorf("Scanner.Column() = %v, want %v", tt.s.Column(), tt.want)
+			}
+		})
+	}
+}

--- a/storage/database/db2/field.go
+++ b/storage/database/db2/field.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/Breeze0806/go-etl/element"
 	"github.com/Breeze0806/go-etl/storage/database"
-	"golang.org/x/text/encoding/simplifiedchinese"
 )
 
 var (
@@ -191,12 +190,12 @@ func (s *Scanner) Scan(src interface{}) (err error) {
 		case nil:
 			cv = element.NewNilStringColumnValue()
 		case []byte:
-			var v []byte
-			v, err = simplifiedchinese.GBK.NewDecoder().Bytes(data)
+			var buf []byte
+			buf, err = decodeChinese(data)
 			if err != nil {
 				return err
 			}
-			cv = element.NewStringColumnValue(string(v))
+			cv = element.NewStringColumnValue(string(buf))
 		default:
 			return fmt.Errorf("src is %v(%T), but not %v", src, src, element.TypeString)
 		}

--- a/storage/database/db2/field_test.go
+++ b/storage/database/db2/field_test.go
@@ -22,16 +22,7 @@ import (
 
 	"github.com/Breeze0806/go-etl/element"
 	"github.com/Breeze0806/go-etl/storage/database"
-	"golang.org/x/text/encoding/simplifiedchinese"
 )
-
-func gbk(data []byte) []byte {
-	v, err := simplifiedchinese.GBK.NewEncoder().Bytes(data)
-	if err != nil {
-		panic(err)
-	}
-	return v
-}
 
 type mockFieldType struct {
 	name string
@@ -662,9 +653,9 @@ func TestScanner_Scan(t *testing.T) {
 			name: "CHAR",
 			s:    NewScanner(NewField(database.NewBaseField(0, "test", newMockFieldType("CHAR")))),
 			args: args{
-				src: gbk([]byte("中文abc")),
+				src: []byte("abc"),
 			},
-			want: element.NewDefaultColumn(element.NewStringColumnValue("中文abc"), "test", element.ByteSize(gbk([]byte("中文abc")))),
+			want: element.NewDefaultColumn(element.NewStringColumnValue("abc"), "test", element.ByteSize([]byte("abc"))),
 		},
 		{
 			name: "CHAR nil",


### PR DESCRIPTION
db2 char在gbk下无法正常读取，通过 https://github.com/ibmdb/go_ibm_db/pull/213 已经合并，但是没有发布