### PR TITLE
fix: column use other sql contains 'as' 

### DIFF
--- a/cmd/datax/examples/oracle/config.json
+++ b/cmd/datax/examples/oracle/config.json
@@ -22,7 +22,7 @@
                         },
                         "username": "system",
                         "password": "oracle",
-                        "column": ["*"],
+                        "column": ["T_NUM","T_DATE","case when T_DATE is null or T_DATE > SYSDATE then 1 else 0 end as \"状态\""],
                         "where": ""
                     }
                 },
@@ -39,7 +39,7 @@
                         "username": "system",
                         "password": "oracle",
                         "writeMode": "insert",
-                        "column": ["*"],
+                        "column": ["T_NUM","T_DATE","T_INT"],
                         "preSql": [],
                         "batchTimeout": "1s",
                         "batchSize":1000

--- a/datax/plugin/reader/dbms/parameter.go
+++ b/datax/plugin/reader/dbms/parameter.go
@@ -103,11 +103,22 @@ func (q *QueryParam) Query(_ []element.Record) (string, error) {
 	if len(q.Table().Fields()) == 0 {
 		return "", errors.NewNoStackError("column is empty")
 	}
+
+	canUseConfig := false
+	if len(q.Table().Fields()) == len(q.Config.GetColumns()) {
+		canUseConfig = true
+	}
+
 	for i, v := range q.Table().Fields() {
 		if i > 0 {
 			buf.WriteString(",")
 		}
-		buf.WriteString(v.Quoted())
+
+		col := v.Select()
+		if canUseConfig && v.Name() != q.Config.GetColumns()[i].GetName() {
+			col = q.Config.GetColumns()[i].GetName()
+		}
+		buf.WriteString(col)
 	}
 	buf.WriteString(" from ")
 	buf.WriteString(q.Table().Quoted())


### PR DESCRIPTION
in reader config:
`"column": ["T_NUM","T_DATE","case when T_DATE is null or T_DATE > SYSDATE then 1 else 0 end as \"状态\""]`

it will do select
`select T_NUM,T_DATE,状态 from xxx`