### PR TITLE
fix: use ubuntu:22.04 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM debian:stable-backports AS base
-
-# if you located in China, you can use aliyun mirrors to speed up
-#RUN sed -i 's@deb.debian.org@mirrors.aliyun.com@g' /etc/apt/sources.list.d/debian.sources
+FROM ubuntu:22.04 AS base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Base image _**debian:stable-backports**_ is not stable
```
2.167 Building dependency tree...
2.256 Reading state information...
2.268 E: Unable to locate package software-properties-common
2.268 E: Unable to locate package libaio1
------
Dockerfile:6
--------------------
   5 |     
   6 | >>> RUN apt-get update && \
   7 | >>>     apt-get install -y --no-install-recommends \
   8 | >>>         ca-certificates \
   9 | >>>         wget \
  10 | >>>         gnupg \
  11 | >>>         software-properties-common \
  12 | >>>         git \
  13 | >>>         build-essential \
  14 | >>>         unzip \
  15 | >>>         libaio1 \
  16 | >>>         && \
  17 | >>>     rm -rf /var/lib/apt/lists/*
  18 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c apt-get update &&     apt-get install -y --no-install-recommends         ca-certificates         wget         gnupg         software-properties-common         git         build-essential         unzip         libaio1         &&     rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```