### PR TITLE
feat: add JSON data type support

### DIFF
--- a/element/big_int_column_value.go
+++ b/element/big_int_column_value.go
@@ -120,6 +120,11 @@ func (b *BigIntColumnValue) AsTime() (time.Time, error) {
 	return time.Time{}, NewTransformErrorFormColumnTypes(b.Type(), TypeTime, fmt.Errorf(" val: %v", b.String()))
 }
 
+// AsJSON - Convert to a JSON number
+func (b *BigIntColumnValue) AsJSON() (JSON, error) {
+	return nil, NewTransformErrorFormColumnTypes(b.Type(), TypeJSON, fmt.Errorf(" val: %v", b.String()))
+}
+
 func (b *BigIntColumnValue) String() string {
 	return b.val.String()
 }

--- a/element/big_int_column_value_test.go
+++ b/element/big_int_column_value_test.go
@@ -769,3 +769,40 @@ func TestNewBigIntColumnValueFromUint64(t *testing.T) {
 		})
 	}
 }
+
+func TestBigIntColumnValue_AsJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		b       *BigIntColumnValue
+		want    JSON
+		wantErr bool
+	}{
+		{
+			name:    "1",
+			b:       NewBigIntColumnValueFromInt64(123456).(*BigIntColumnValue),
+			wantErr: true,
+		},
+		{
+			name:    "2",
+			b:       NewBigIntColumnValueFromInt64(0).(*BigIntColumnValue),
+			wantErr: true,
+		},
+		{
+			name:    "3",
+			b:       NewBigIntColumnValueFromInt64(-999999).(*BigIntColumnValue),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.b.AsJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BigIntColumnValue.AsJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BigIntColumnValue.AsJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/element/bool_column_value.go
+++ b/element/bool_column_value.go
@@ -102,6 +102,11 @@ func (b *BoolColumnValue) AsTime() (time.Time, error) {
 	return time.Time{}, NewTransformErrorFormColumnTypes(b.Type(), TypeTime, fmt.Errorf(" val: %v", b.String()))
 }
 
+// AsJSON converts to a JSON boolean
+func (b *BoolColumnValue) AsJSON() (JSON, error) {
+	return nil, NewTransformErrorFormColumnTypes(b.Type(), TypeJSON, fmt.Errorf(" val: %v", b.String()))
+}
+
 func (b *BoolColumnValue) String() string {
 	if b.val {
 		return "true"

--- a/element/bool_column_value_test.go
+++ b/element/bool_column_value_test.go
@@ -397,3 +397,35 @@ func TestBoolColumnValue_Cmp(t *testing.T) {
 		})
 	}
 }
+
+func TestBoolColumnValue_AsJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		b       *BoolColumnValue
+		want    JSON
+		wantErr bool
+	}{
+		{
+			name:    "1",
+			b:       NewBoolColumnValue(true).(*BoolColumnValue),
+			wantErr: true,
+		},
+		{
+			name:    "2",
+			b:       NewBoolColumnValue(false).(*BoolColumnValue),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.b.AsJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BoolColumnValue.AsJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BoolColumnValue.AsJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/element/bytes_column_value.go
+++ b/element/bytes_column_value.go
@@ -132,6 +132,11 @@ func (b *BytesColumnValue) AsTime() (t time.Time, err error) {
 	return
 }
 
+// AsJSON - Convert to JSON
+func (b *BytesColumnValue) AsJSON() (JSON, error) {
+	return _DefaultJSONConverter.ConvertFromBytes(b.val)
+}
+
 func (b *BytesColumnValue) String() string {
 	return string(b.val)
 }

--- a/element/bytes_column_value_test.go
+++ b/element/bytes_column_value_test.go
@@ -524,3 +524,60 @@ func TestBytesColumnValue_Cmp(t *testing.T) {
 		})
 	}
 }
+
+func TestBytesColumnValue_AsJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		b       *BytesColumnValue
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "1",
+			b:    NewBytesColumnValue([]byte(`{"key": "value"}`)).(*BytesColumnValue),
+			want: `{"key": "value"}`,
+		},
+		{
+			name: "2",
+			b:    NewBytesColumnValue([]byte(`[1, 2, 3]`)).(*BytesColumnValue),
+			want: `[1, 2, 3]`,
+		},
+		{
+			name:    "3",
+			b:       NewBytesColumnValue([]byte(`invalid json`)).(*BytesColumnValue),
+			wantErr: true,
+		},
+		{
+			name: "4",
+			b:    NewBytesColumnValue([]byte(`"hello"`)).(*BytesColumnValue),
+			want: `"hello"`,
+		},
+		{
+			name: "5",
+			b:    NewBytesColumnValue([]byte(`123`)).(*BytesColumnValue),
+			want: `123`,
+		},
+		{
+			name: "6",
+			b:    NewBytesColumnValue([]byte(`true`)).(*BytesColumnValue),
+			want: `true`,
+		},
+		{
+			name: "7",
+			b:    NewBytesColumnValue([]byte(`null`)).(*BytesColumnValue),
+			want: `null`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.b.AsJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BytesColumnValue.AsJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got.ToString() != tt.want {
+				t.Errorf("BytesColumnValue.AsJSON() = %v, want %v", got.ToString(), tt.want)
+			}
+		})
+	}
+}

--- a/element/column.go
+++ b/element/column.go
@@ -32,6 +32,7 @@ const (
 	TypeString  ColumnType = "string"  // StringType: String type
 	TypeBytes   ColumnType = "bytes"   // BytesType: Byte stream type
 	TypeTime    ColumnType = "time"    // TimeType: Time type
+	TypeJSON    ColumnType = "json"    // TimeType: Time type
 )
 
 // String Printing display
@@ -51,6 +52,7 @@ type ColumnValue interface {
 	AsString() (string, error)         // ToString: Convert to string
 	AsBytes() ([]byte, error)          // ToBytes: Convert to byte stream
 	AsTime() (time.Time, error)        // ToTime: Convert to time
+	AsJSON() (JSON, error)             // ToJSON: Convert to JSON
 }
 
 // ColumnValueClonable Cloneable column value
@@ -123,6 +125,11 @@ func (n *nilColumnValue) AsBytes() ([]byte, error) {
 // AsTime Failed to convert to time
 func (n *nilColumnValue) AsTime() (time.Time, error) {
 	return time.Time{}, ErrNilValue
+}
+
+// AsJSON Failed to convert to JSON
+func (n *nilColumnValue) AsJSON() (JSON, error) {
+	return nil, ErrNilValue
 }
 
 // String Printing display

--- a/element/column_test.go
+++ b/element/column_test.go
@@ -247,6 +247,33 @@ func Test_nilColumnValue_AsTime(t *testing.T) {
 	}
 }
 
+func Test_nilColumnValue_AsJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		n       *nilColumnValue
+		want    JSON
+		wantErr bool
+	}{
+		{
+			name:    "1",
+			n:       &nilColumnValue{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.n.AsJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("nilColumnValue.AsJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("nilColumnValue.AsJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_nilColumnValue_String(t *testing.T) {
 	tests := []struct {
 		name string

--- a/element/decimal_column_value.go
+++ b/element/decimal_column_value.go
@@ -120,6 +120,11 @@ func (d *DecimalColumnValue) AsTime() (time.Time, error) {
 	return time.Time{}, NewTransformErrorFormColumnTypes(d.Type(), TypeTime, fmt.Errorf(" val: %v", d.String()))
 }
 
+// AsJSON converts to a JSON number
+func (d *DecimalColumnValue) AsJSON() (JSON, error) {
+	return nil, NewTransformErrorFormColumnTypes(d.Type(), TypeJSON, fmt.Errorf(" val: %v", d.String()))
+}
+
 func (d *DecimalColumnValue) String() string {
 	return d.val.String()
 }

--- a/element/decimal_column_value_test.go
+++ b/element/decimal_column_value_test.go
@@ -761,3 +761,35 @@ func TestNewDecimalColumnValueFromFloat32(t *testing.T) {
 		})
 	}
 }
+
+func TestDecimalColumnValue_AsJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		d       *DecimalColumnValue
+		want    JSON
+		wantErr bool
+	}{
+		{
+			name:    "1",
+			d:       NewDecimalColumnValueFromFloat(123.456).(*DecimalColumnValue),
+			wantErr: true,
+		},
+		{
+			name:    "2",
+			d:       NewDecimalColumnValue(_DecimalZero).(*DecimalColumnValue),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.d.AsJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DecimalColumnValue.AsJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DecimalColumnValue.AsJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/element/json.go
+++ b/element/json.go
@@ -1,0 +1,66 @@
+// Copyright 2020 the go-etl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package element
+
+import (
+	"github.com/Breeze0806/go/encoding"
+)
+
+// JSON is the JSON interface
+type JSON interface {
+	ToString() string
+	ToBytes() []byte
+	Clone() JSON
+}
+
+// DefaultJSON is a wrapper for encoding.JSON to implement element.JSON interface
+type DefaultJSON struct {
+	json *encoding.JSON
+}
+
+// NewDefaultJSON creates a new JSON element from encoding.JSON
+func NewDefaultJSON(j *encoding.JSON) JSON {
+	return &DefaultJSON{json: j}
+}
+
+// ToString returns the string representation of the JSON
+func (j *DefaultJSON) ToString() string {
+	if j.json == nil {
+		return ""
+	}
+	return j.json.String()
+}
+
+// ToBytes returns the byte representation of the JSON
+func (j *DefaultJSON) ToBytes() []byte {
+	if j.json == nil {
+		return nil
+	}
+	b, _ := j.json.MarshalJSON()
+	return b
+}
+
+// GetJSON returns the underlying encoding.JSON
+func (j *DefaultJSON) GetJSON() *encoding.JSON {
+	return j.json
+}
+
+// Clone clones the JSON
+func (j *DefaultJSON) Clone() JSON {
+	if j.json == nil {
+		return &DefaultJSON{json: nil}
+	}
+	return &DefaultJSON{json: j.json.Clone()}
+}

--- a/element/json_column_value.go
+++ b/element/json_column_value.go
@@ -1,0 +1,132 @@
+// Copyright 2020 the go-etl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package element
+
+import (
+	"fmt"
+	"time"
+)
+
+// NilJsonColumnValue represents a nil JSON column value
+type NilJsonColumnValue struct {
+	*nilColumnValue
+}
+
+// NewNilJsonColumnValue creates a nil JSON column value
+func NewNilJsonColumnValue() ColumnValue {
+	return &NilJsonColumnValue{
+		nilColumnValue: &nilColumnValue{},
+	}
+}
+
+// Type returns the type of the column
+func (n *NilJsonColumnValue) Type() ColumnType {
+	return TypeJSON
+}
+
+// Clone clones a nil JSON column value
+func (n *NilJsonColumnValue) Clone() ColumnValue {
+	return NewNilJsonColumnValue()
+}
+
+// JsonColumnValue represents a JSON column value
+type JsonColumnValue struct {
+	notNilColumnValue
+
+	val JSON // JSON Value
+}
+
+// NewJsonColumnValueFromString creates a JSON column value from a string
+func NewJsonColumnValueFromString(s string) (ColumnValue, error) {
+	json, err := _DefaultJSONConverter.ConvertFromString(s)
+	if err != nil {
+		return nil, err
+	}
+	return &JsonColumnValue{val: json}, nil
+}
+
+// NewJsonColumnValueFromBytes creates a JSON column value from bytes
+func NewJsonColumnValueFromBytes(b []byte) (ColumnValue, error) {
+	json, err := _DefaultJSONConverter.ConvertFromBytes(b)
+	if err != nil {
+		return nil, err
+	}
+	return &JsonColumnValue{val: json}, nil
+}
+
+// Type returns the type of the column
+func (j *JsonColumnValue) Type() ColumnType {
+	return TypeJSON
+}
+
+// AsBool cannot convert to a boolean
+func (j *JsonColumnValue) AsBool() (bool, error) {
+	return false, NewTransformErrorFormColumnTypes(j.Type(), TypeBool, fmt.Errorf(" val: %v", j.String()))
+}
+
+// AsBigInt cannot convert to a big integer
+func (j *JsonColumnValue) AsBigInt() (BigIntNumber, error) {
+	return nil, NewTransformErrorFormColumnTypes(j.Type(), TypeBigInt, fmt.Errorf(" val: %v", j.String()))
+}
+
+// AsDecimal cannot convert to a high-precision decimal number
+func (j *JsonColumnValue) AsDecimal() (DecimalNumber, error) {
+	return nil, NewTransformErrorFormColumnTypes(j.Type(), TypeDecimal, fmt.Errorf(" val: %v", j.String()))
+}
+
+// AsString converts it to a string
+func (j *JsonColumnValue) AsString() (string, error) {
+	return j.val.ToString(), nil
+}
+
+// AsBytes converts it to a byte stream
+func (j *JsonColumnValue) AsBytes() ([]byte, error) {
+	return j.val.ToBytes(), nil
+}
+
+// AsTime cannot convert to a time value
+func (j *JsonColumnValue) AsTime() (time.Time, error) {
+	return time.Time{}, NewTransformErrorFormColumnTypes(j.Type(), TypeTime, fmt.Errorf(" val: %v", j.String()))
+}
+
+// AsJSON converts to a JSON value
+func (j *JsonColumnValue) AsJSON() (JSON, error) {
+	return j.val, nil
+}
+
+func (j *JsonColumnValue) String() string {
+	return j.val.ToString()
+}
+
+// Clone clones a JSON column value
+func (j *JsonColumnValue) Clone() ColumnValue {
+	return &JsonColumnValue{val: j.val.Clone()}
+}
+
+// Cmp Returns 1 for greater than, 0 for equal, and -1 for less than
+func (j *JsonColumnValue) Cmp(right ColumnValue) (int, error) {
+	rightValue, err := right.AsString()
+	if err != nil {
+		return 0, err
+	}
+
+	if j.val.ToString() > rightValue {
+		return 1, nil
+	}
+	if j.val.ToString() == rightValue {
+		return 0, nil
+	}
+	return -1, nil
+}

--- a/element/json_column_value_test.go
+++ b/element/json_column_value_test.go
@@ -1,0 +1,567 @@
+// Copyright 2020 the go-etl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package element
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewNilJsonColumnValue(t *testing.T) {
+	tests := []struct {
+		name string
+		want ColumnValue
+	}{
+		{
+			name: "1",
+			want: &NilJsonColumnValue{
+				nilColumnValue: &nilColumnValue{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewNilJsonColumnValue(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewNilJsonColumnValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNilJsonColumnValue_Type(t *testing.T) {
+	tests := []struct {
+		name string
+		n    *NilJsonColumnValue
+		want ColumnType
+	}{
+		{
+			name: "1",
+			n:    NewNilJsonColumnValue().(*NilJsonColumnValue),
+			want: TypeJSON,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.n.Type(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NilJsonColumnValue.Type() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNilJsonColumnValue_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		n    *NilJsonColumnValue
+		want ColumnValue
+	}{
+		{
+			name: "1",
+			n:    NewNilJsonColumnValue().(*NilJsonColumnValue),
+			want: NewNilJsonColumnValue(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.n.Clone()
+			if got == tt.n {
+				t.Errorf("NilJsonColumnValue.Clone() = %p, n %p", got, tt.n)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NilJsonColumnValue.Clone() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewJsonColumnValueFromString(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "1",
+			args: args{
+				s: `{"a":1}`,
+			},
+			want: `{"a":1}`,
+		},
+		{
+			name: "2",
+			args: args{
+				s: `[1,2,3]`,
+			},
+			want: `[1,2,3]`,
+		},
+		{
+			name: "3",
+			args: args{
+				s: `"hello"`,
+			},
+			want: `"hello"`,
+		},
+		{
+			name: "4",
+			args: args{
+				s: `123`,
+			},
+			want: `123`,
+		},
+		{
+			name:    "5",
+			args:    args{s: `invalid json`},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewJsonColumnValueFromString(tt.args.s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewJsonColumnValueFromString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got.String() != tt.want {
+				t.Errorf("NewJsonColumnValueFromString() = %v, want %v", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestNewJsonColumnValueFromBytes(t *testing.T) {
+	type args struct {
+		b []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "1",
+			args: args{
+				b: []byte(`{"a":1}`),
+			},
+			want: `{"a":1}`,
+		},
+		{
+			name: "2",
+			args: args{
+				b: []byte(`[1,2,3]`),
+			},
+			want: `[1,2,3]`,
+		},
+		{
+			name:    "3",
+			args:    args{b: []byte(`invalid json`)},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewJsonColumnValueFromBytes(tt.args.b)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewJsonColumnValueFromBytes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got.String() != tt.want {
+				t.Errorf("NewJsonColumnValueFromBytes() = %v, want %v", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestJsonColumnValue_Type(t *testing.T) {
+	tests := []struct {
+		name string
+		j    *JsonColumnValue
+		want ColumnType
+	}{
+		{
+			name: "1",
+			j:    getTestJsonColumnValue(`{"a":1}`),
+			want: TypeJSON,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.j.Type(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("JsonColumnValue.Type() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJsonColumnValue_AsBool(t *testing.T) {
+	tests := []struct {
+		name    string
+		j       *JsonColumnValue
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "1",
+			j:       getTestJsonColumnValue(`{"a":1}`),
+			wantErr: true,
+		},
+		{
+			name:    "2",
+			j:       getTestJsonColumnValue(`true`),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.j.AsBool()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JsonColumnValue.AsBool() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("JsonColumnValue.AsBool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJsonColumnValue_AsBigInt(t *testing.T) {
+	tests := []struct {
+		name    string
+		j       *JsonColumnValue
+		wantErr bool
+	}{
+		{
+			name:    "1",
+			j:       getTestJsonColumnValue(`{"a":1}`),
+			wantErr: true,
+		},
+		{
+			name:    "2",
+			j:       getTestJsonColumnValue(`123`),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.j.AsBigInt()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JsonColumnValue.AsBigInt() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil {
+				t.Errorf("JsonColumnValue.AsBigInt() = %v, want nil", got)
+			}
+		})
+	}
+}
+
+func TestJsonColumnValue_AsDecimal(t *testing.T) {
+	tests := []struct {
+		name    string
+		j       *JsonColumnValue
+		wantErr bool
+	}{
+		{
+			name:    "1",
+			j:       getTestJsonColumnValue(`{"a":1}`),
+			wantErr: true,
+		},
+		{
+			name:    "2",
+			j:       getTestJsonColumnValue(`123.45`),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.j.AsDecimal()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JsonColumnValue.AsDecimal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil {
+				t.Errorf("JsonColumnValue.AsDecimal() = %v, want nil", got)
+			}
+		})
+	}
+}
+
+func TestJsonColumnValue_AsString(t *testing.T) {
+	tests := []struct {
+		name    string
+		j       *JsonColumnValue
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "1",
+			j:    getTestJsonColumnValue(`{"a":1}`),
+			want: `{"a":1}`,
+		},
+		{
+			name: "2",
+			j:    getTestJsonColumnValue(`[1,2,3]`),
+			want: `[1,2,3]`,
+		},
+		{
+			name: "3",
+			j:    getTestJsonColumnValue(`"hello"`),
+			want: `"hello"`,
+		},
+		{
+			name: "4",
+			j:    getTestJsonColumnValue(`123`),
+			want: `123`,
+		},
+		{
+			name: "5",
+			j:    getTestJsonColumnValue(`true`),
+			want: `true`,
+		},
+		{
+			name: "6",
+			j:    getTestJsonColumnValue(`null`),
+			want: `null`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.j.AsString()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JsonColumnValue.AsString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("JsonColumnValue.AsString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJsonColumnValue_AsBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		j       *JsonColumnValue
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "1",
+			j:    getTestJsonColumnValue(`{"a":1}`),
+			want: []byte(`{"a":1}`),
+		},
+		{
+			name: "2",
+			j:    getTestJsonColumnValue(`[1,2,3]`),
+			want: []byte(`[1,2,3]`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.j.AsBytes()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JsonColumnValue.AsBytes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("JsonColumnValue.AsBytes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJsonColumnValue_AsTime(t *testing.T) {
+	tests := []struct {
+		name    string
+		j       *JsonColumnValue
+		wantErr bool
+	}{
+		{
+			name:    "1",
+			j:       getTestJsonColumnValue(`{"a":1}`),
+			wantErr: true,
+		},
+		{
+			name:    "2",
+			j:       getTestJsonColumnValue(`"2020-01-01"`),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.j.AsTime()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JsonColumnValue.AsTime() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestJsonColumnValue_AsJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		j       *JsonColumnValue
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "1",
+			j:    getTestJsonColumnValue(`{"a":1}`),
+			want: `{"a":1}`,
+		},
+		{
+			name: "2",
+			j:    getTestJsonColumnValue(`[1,2,3]`),
+			want: `[1,2,3]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.j.AsJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JsonColumnValue.AsJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got.ToString() != tt.want {
+				t.Errorf("JsonColumnValue.AsJSON() = %v, want %v", got.ToString(), tt.want)
+			}
+		})
+	}
+}
+
+func TestJsonColumnValue_String(t *testing.T) {
+	tests := []struct {
+		name string
+		j    *JsonColumnValue
+		want string
+	}{
+		{
+			name: "1",
+			j:    getTestJsonColumnValue(`{"a":1}`),
+			want: `{"a":1}`,
+		},
+		{
+			name: "2",
+			j:    getTestJsonColumnValue(`[1,2,3]`),
+			want: `[1,2,3]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.j.String(); got != tt.want {
+				t.Errorf("JsonColumnValue.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJsonColumnValue_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		j    *JsonColumnValue
+	}{
+		{
+			name: "1",
+			j:    getTestJsonColumnValue(`{"a":1}`),
+		},
+		{
+			name: "2",
+			j:    getTestJsonColumnValue(`[1,2,3]`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.j.Clone()
+			if got == tt.j {
+				t.Errorf("JsonColumnValue.Clone() = %p, j %p", got, tt.j)
+			}
+			if got.String() != tt.j.String() {
+				t.Errorf("JsonColumnValue.Clone() = %v, want %v", got.String(), tt.j.String())
+			}
+		})
+	}
+}
+
+func TestJsonColumnValue_Cmp(t *testing.T) {
+	type args struct {
+		right ColumnValue
+	}
+	tests := []struct {
+		name    string
+		j       *JsonColumnValue
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "1",
+			j:    getTestJsonColumnValue(`{"a":1}`),
+			args: args{
+				right: getTestJsonColumnValue(`{"a":1}`),
+			},
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name: "2",
+			j:    getTestJsonColumnValue(`{"a":1}`),
+			args: args{
+				right: getTestJsonColumnValue(`{"a":2}`),
+			},
+			want:    -1,
+			wantErr: false,
+		},
+		{
+			name: "3",
+			j:    getTestJsonColumnValue(`{"a":2}`),
+			args: args{
+				right: getTestJsonColumnValue(`{"a":1}`),
+			},
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name: "4",
+			j:    getTestJsonColumnValue(`[1,2,3]`),
+			args: args{
+				right: NewNilJsonColumnValue(),
+			},
+			want:    0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.j.Cmp(tt.args.right)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JsonColumnValue.Cmp() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("JsonColumnValue.Cmp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func getTestJsonColumnValue(s string) *JsonColumnValue {
+	cv, _ := NewJsonColumnValueFromString(s)
+	return cv.(*JsonColumnValue)
+}

--- a/element/json_convertor.go
+++ b/element/json_convertor.go
@@ -1,0 +1,53 @@
+// Copyright 2020 the go-etl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package element
+
+import (
+	"github.com/Breeze0806/go/encoding"
+)
+
+var _DefaultJSONConverter JSONConverter = NewDefaultJSONConverter()
+
+// JSONConverter is the JSON converter interface
+type JSONConverter interface {
+	ConvertFromString(s string) (json JSON, err error)
+	ConvertFromBytes(b []byte) (json JSON, err error)
+}
+
+// DefaultJSONConverter implements JSONConverter interface
+type DefaultJSONConverter struct{}
+
+// NewDefaultJSONConverter creates a new JSON converter
+func NewDefaultJSONConverter() JSONConverter {
+	return &DefaultJSONConverter{}
+}
+
+// ConvertFromString converts a string to JSON
+func (c *DefaultJSONConverter) ConvertFromString(s string) (JSON, error) {
+	json, err := encoding.NewJSONFromString(s)
+	if err != nil {
+		return nil, err
+	}
+	return NewDefaultJSON(json), nil
+}
+
+// ConvertFromBytes converts bytes to JSON
+func (c *DefaultJSONConverter) ConvertFromBytes(b []byte) (JSON, error) {
+	json, err := encoding.NewJSONFromBytes(b)
+	if err != nil {
+		return nil, err
+	}
+	return NewDefaultJSON(json), nil
+}

--- a/element/json_convertor_test.go
+++ b/element/json_convertor_test.go
@@ -1,0 +1,95 @@
+// Copyright 2020 the go-etl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package element
+
+import (
+	"testing"
+)
+
+func TestJsonConverter_ConvertFromString(t *testing.T) {
+	converter := NewDefaultJSONConverter()
+	tests := []struct {
+		name    string
+		s       string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "1",
+			s:    `{"a":1}`,
+			want: `{"a":1}`,
+		},
+		{
+			name: "2",
+			s:    `[1,2,3]`,
+			want: `[1,2,3]`,
+		},
+		{
+			name:    "3",
+			s:       `invalid json`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := converter.ConvertFromString(tt.s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("jsonConverter.ConvertFromString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got.ToString() != tt.want {
+				t.Errorf("jsonConverter.ConvertFromString() = %v, want %v", got.ToString(), tt.want)
+			}
+		})
+	}
+}
+
+func TestJsonConverter_ConvertFromBytes(t *testing.T) {
+	converter := NewDefaultJSONConverter()
+	tests := []struct {
+		name    string
+		b       []byte
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "1",
+			b:    []byte(`{"a":1}`),
+			want: []byte(`{"a":1}`),
+		},
+		{
+			name: "2",
+			b:    []byte(`[1,2,3]`),
+			want: []byte(`[1,2,3]`),
+		},
+		{
+			name:    "3",
+			b:       []byte(`invalid json`),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := converter.ConvertFromBytes(tt.b)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("jsonConverter.ConvertFromBytes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && string(got.ToBytes()) != string(tt.want) {
+				t.Errorf("jsonConverter.ConvertFromBytes() = %v, want %v", got.ToBytes(), tt.want)
+			}
+		})
+	}
+}

--- a/element/json_test.go
+++ b/element/json_test.go
@@ -1,0 +1,183 @@
+// Copyright 2020 the go-etl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package element
+
+import (
+	"testing"
+
+	"github.com/Breeze0806/go/encoding"
+)
+
+func TestJsonWrapper_ToString(t *testing.T) {
+	tests := []struct {
+		name string
+		json *encoding.JSON
+		want string
+	}{
+		{
+			name: "1",
+			json: func() *encoding.JSON {
+				j, _ := encoding.NewJSONFromString(`{"a":1}`)
+				return j
+			}(),
+			want: `{"a":1}`,
+		},
+		{
+			name: "2",
+			json: func() *encoding.JSON {
+				j, _ := encoding.NewJSONFromString(`[1,2,3]`)
+				return j
+			}(),
+			want: `[1,2,3]`,
+		},
+		{
+			name: "3",
+			json: nil,
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := NewDefaultJSON(tt.json)
+			if got := j.ToString(); got != tt.want {
+				t.Errorf("jsonWrapper.ToString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJsonWrapper_ToBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		json *encoding.JSON
+		want []byte
+	}{
+		{
+			name: "1",
+			json: func() *encoding.JSON {
+				j, _ := encoding.NewJSONFromString(`{"a":1}`)
+				return j
+			}(),
+			want: []byte(`{"a":1}`),
+		},
+		{
+			name: "2",
+			json: func() *encoding.JSON {
+				j, _ := encoding.NewJSONFromString(`[1,2,3]`)
+				return j
+			}(),
+			want: []byte(`[1,2,3]`),
+		},
+		{
+			name: "3",
+			json: nil,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := NewDefaultJSON(tt.json)
+			if got := j.ToBytes(); string(got) != string(tt.want) {
+				t.Errorf("jsonWrapper.ToBytes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultJSON_Clone(t *testing.T) {
+	tests := []struct {
+		name string
+		json *encoding.JSON
+		want string
+	}{
+		{
+			name: "1",
+			json: func() *encoding.JSON {
+				j, _ := encoding.NewJSONFromString(`{"a":1}`)
+				return j
+			}(),
+			want: `{"a":1}`,
+		},
+		{
+			name: "2",
+			json: func() *encoding.JSON {
+				j, _ := encoding.NewJSONFromString(`[1,2,3]`)
+				return j
+			}(),
+			want: `[1,2,3]`,
+		},
+		{
+			name: "3",
+			json: nil,
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := NewDefaultJSON(tt.json)
+			got := j.Clone()
+			if got == j {
+				t.Errorf("DefaultJSON.Clone() = %p, j %p", got, j)
+			}
+			if got.ToString() != tt.want {
+				t.Errorf("DefaultJSON.Clone() = %v, want %v", got.ToString(), tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultJSON_GetJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		json *encoding.JSON
+		want *encoding.JSON
+	}{
+		{
+			name: "1",
+			json: func() *encoding.JSON {
+				j, _ := encoding.NewJSONFromString(`{"a":1}`)
+				return j
+			}(),
+			want: func() *encoding.JSON {
+				j, _ := encoding.NewJSONFromString(`{"a":1}`)
+				return j
+			}(),
+		},
+		{
+			name: "2",
+			json: nil,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := NewDefaultJSON(tt.json).(*DefaultJSON)
+			got := j.GetJSON()
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("DefaultJSON.GetJSON() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Errorf("DefaultJSON.GetJSON() = nil, want %v", tt.want)
+				return
+			}
+			if got.String() != tt.want.String() {
+				t.Errorf("DefaultJSON.GetJSON() = %v, want %v", got.String(), tt.want.String())
+			}
+		})
+	}
+}

--- a/element/string_column_value.go
+++ b/element/string_column_value.go
@@ -99,7 +99,7 @@ func (s *StringColumnValue) AsDecimal() (DecimalNumber, error) {
 
 // AsString - Convert to a string
 func (s *StringColumnValue) AsString() (string, error) {
-	return s.val, nil
+	return s.String(), nil
 }
 
 // AsBytes - Convert to a byte stream
@@ -114,6 +114,11 @@ func (s *StringColumnValue) AsTime() (t time.Time, err error) {
 		return time.Time{}, NewTransformErrorFormColumnTypes(s.Type(), TypeTime, fmt.Errorf("err: %v val: %v", err, s.val))
 	}
 	return
+}
+
+// AsJSON - Convert to a JSON string
+func (s *StringColumnValue) AsJSON() (JSON, error) {
+	return _DefaultJSONConverter.ConvertFromString(s.val)
 }
 
 func (s *StringColumnValue) String() string {

--- a/element/string_column_value_test.go
+++ b/element/string_column_value_test.go
@@ -508,3 +508,60 @@ func TestStringColumnValue_Cmp(t *testing.T) {
 		})
 	}
 }
+
+func TestStringColumnValue_AsJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		s       *StringColumnValue
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "1",
+			s:    NewStringColumnValue(`{"key": "value"}`).(*StringColumnValue),
+			want: `{"key": "value"}`,
+		},
+		{
+			name: "2",
+			s:    NewStringColumnValue(`[1, 2, 3]`).(*StringColumnValue),
+			want: `[1, 2, 3]`,
+		},
+		{
+			name:    "3",
+			s:       NewStringColumnValue(`invalid json`).(*StringColumnValue),
+			wantErr: true,
+		},
+		{
+			name: "4",
+			s:    NewStringColumnValue(`"hello"`).(*StringColumnValue),
+			want: `"hello"`,
+		},
+		{
+			name: "5",
+			s:    NewStringColumnValue(`123`).(*StringColumnValue),
+			want: `123`,
+		},
+		{
+			name: "6",
+			s:    NewStringColumnValue(`true`).(*StringColumnValue),
+			want: `true`,
+		},
+		{
+			name: "7",
+			s:    NewStringColumnValue(`null`).(*StringColumnValue),
+			want: `null`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.s.AsJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("StringColumnValue.AsJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got.ToString() != tt.want {
+				t.Errorf("StringColumnValue.AsJSON() = %v, want %v", got.ToString(), tt.want)
+			}
+		})
+	}
+}

--- a/element/time_column_value.go
+++ b/element/time_column_value.go
@@ -107,6 +107,11 @@ func (t *TimeColumnValue) AsTime() (time.Time, error) {
 	return t.val, nil
 }
 
+// AsJSON Converts to a JSON string
+func (t *TimeColumnValue) AsJSON() (JSON, error) {
+	return nil, NewTransformErrorFormColumnTypes(t.Type(), TypeJSON, fmt.Errorf(" val: %v", t.String()))
+}
+
 func (t *TimeColumnValue) String() string {
 	return t.val.Format(DefaultTimeFormat)
 }

--- a/element/time_column_value_test.go
+++ b/element/time_column_value_test.go
@@ -338,3 +338,30 @@ func TestTimeColumnValue_Cmp(t *testing.T) {
 		})
 	}
 }
+
+func TestTimeColumnValue_AsJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		t       *TimeColumnValue
+		want    JSON
+		wantErr bool
+	}{
+		{
+			name:    "1",
+			t:       NewTimeColumnValue(time.Date(2020, 12, 17, 22, 49, 56, 69-999-999, time.Local)).(*TimeColumnValue),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.t.AsJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TimeColumnValue.AsJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TimeColumnValue.AsJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
add JSON data type support in go-etl

## Motivation and Context

#75 need json type, other such as mongodb, es eg. also need it.

- Add JsonColumnValue implementation with JSON interface
- Add AsJSON() method to all ColumnValue types
- Add JSONConverter for string/bytes to JSON conversion
- Support JSON conversion between bytes and string types
- Update README with JSON type documentation

```go
// JSON is the JSON interface
type JSON interface {
	ToString() string
	ToBytes() []byte
	Clone() JSON
}
// JSONConverter is the JSON converter interface
type JSONConverter interface {
	ConvertFromString(s string) (json JSON, err error)
	ConvertFromBytes(b []byte) (json JSON, err error)
}
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## How Has This Been Tested?

use go test in element

## Checklist

<!-- Please review and check the following items -->
- [x] My code follows the project's code style and conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Breaking Changes

None

## Related Issues

None

## Additional Notes

None

